### PR TITLE
CheckReturn checked the wrong value for isUndefined

### DIFF
--- a/js/src/vm/PortableBaselineInterpret.cpp
+++ b/js/src/vm/PortableBaselineInterpret.cpp
@@ -4402,13 +4402,18 @@ dispatch:
 
     CASE(CheckReturn) {
       Value thisval = POP().asValue();
-      if (frame->returnValue().isObject()) {
-        PUSH(StackVal(frame->returnValue()));
-      } else if (!ret->isUndefined()) {
+      // inlined version of frame->checkReturn(thisval, result) (js/src/vm/Stack.cpp)
+      // except we call PUSH_EXIT_FRAME before any function call to report an error
+      // and if checkReturn would return false then we `goto error`
+      // and otherwise we PUSH(StackVal(result))
+      HandleValue retVal = frame->returnValue();
+      if (retVal.isObject()) {
+        PUSH(StackVal(retVal));
+      } else if (!retVal.isUndefined()) {
         PUSH_EXIT_FRAME();
-        state.value0 = frame->returnValue();
-        ReportValueError(cx, JSMSG_BAD_DERIVED_RETURN, JSDVG_IGNORE_STACK,
-                         state.value0, nullptr);
+        state.value0 = retVal; // is this necessary?
+        ReportValueError(cx, JSMSG_BAD_DERIVED_RETURN, JSDVG_IGNORE_STACK, retVal,
+                         nullptr);
         goto error;
       } else if (thisval.isMagic(JS_UNINITIALIZED_LEXICAL)) {
         PUSH_EXIT_FRAME();

--- a/js/src/vm/PortableBaselineInterpret.cpp
+++ b/js/src/vm/PortableBaselineInterpret.cpp
@@ -4402,18 +4402,15 @@ dispatch:
 
     CASE(CheckReturn) {
       Value thisval = POP().asValue();
-      // inlined version of frame->checkReturn(thisval, result) (js/src/vm/Stack.cpp)
-      // except we call PUSH_EXIT_FRAME before any function call to report an error
-      // and if checkReturn would return false then we `goto error`
-      // and otherwise we PUSH(StackVal(result))
+      // inlined version of frame->checkReturn(thisval, result)
+      // (js/src/vm/Stack.cpp).
       HandleValue retVal = frame->returnValue();
       if (retVal.isObject()) {
         PUSH(StackVal(retVal));
       } else if (!retVal.isUndefined()) {
         PUSH_EXIT_FRAME();
-        state.value0 = retVal; // is this necessary?
-        ReportValueError(cx, JSMSG_BAD_DERIVED_RETURN, JSDVG_IGNORE_STACK, retVal,
-                         nullptr);
+        MOZ_ALWAYS_FALSE(ReportValueError(cx, JSMSG_BAD_DERIVED_RETURN,
+                                          JSDVG_IGNORE_STACK, retVal, nullptr));
         goto error;
       } else if (thisval.isMagic(JS_UNINITIALIZED_LEXICAL)) {
         PUSH_EXIT_FRAME();


### PR DESCRIPTION
To verify that the pbl implementation of CheckReturn matched the version from InterpreterFrame that it's derived from, I first extracted the frame->returnValue() call to a variable named retVal to minimize the differences.

Then it was easier to see that the second `if` was checking `ret->isUndefined()` instead of `retVal.isUndefined()`, leading to failure of eight tests in js/src/jit-test/tests/class/.

With this fixed, all but one of the class/ tests pass.